### PR TITLE
options["amount"] converted to a float in validate_event

### DIFF
--- a/buy_crypto_from_gemini.py
+++ b/buy_crypto_from_gemini.py
@@ -23,6 +23,7 @@ def validate_event(event, defaults={}):
     print("validating options: " + json.dumps(options))
     assert "currency" in options, REQUIRED_PARAM.format("currency")
     assert "amount" in options, REQUIRED_PARAM.format("amount")
+    options["amount"] = float(options["amount"])
     assert options["amount"] > 0, "Amount ({}) must be greater than zero".format(
         options["amount"]
     )


### PR DESCRIPTION
`assert options["amount"] > 0` throws unclear comparison type error if passed in as string.